### PR TITLE
Add tests using ava

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "hapi plugin for @sentry/node",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "ava test.js --serial",
     "precommit": "lint-staged",
     "lint": "eslint --ignore-path .gitignore .",
     "lint-fix": "eslint --fix --ignore-path .gitignore ."
@@ -35,7 +35,10 @@
   },
   "devDependencies": {
     "@hydrant/eslint-config": "^2.0.1",
+    "ava": "^1.0.0-rc.2",
     "eslint": "^5.8.0",
-    "lint-staged": "^8.0.4"
+    "hapi": "^17.7.0",
+    "lint-staged": "^8.0.4",
+    "p-defer": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "*.js": "eslint"
   },
   "eslintConfig": {
-    "extends": "@hydrant/eslint-config/modern"
+    "extends": [
+      "@hydrant/eslint-config/modern",
+      "plugin:ava/recommended"
+    ]
   },
   "repository": {
     "type": "git",
@@ -37,6 +40,7 @@
     "@hydrant/eslint-config": "^2.0.1",
     "ava": "^1.0.0-rc.2",
     "eslint": "^5.8.0",
+    "eslint-plugin-ava": "^5.1.1",
     "hapi": "^17.7.0",
     "lint-staged": "^8.0.4",
     "p-defer": "^1.0.0"

--- a/test.js
+++ b/test.js
@@ -35,7 +35,7 @@ test('exposes the sentry client', async t => {
   await server.register({
     plugin,
     options: {
-      client: { dsn, beforeSend: e => e },
+      client: { dsn },
     },
   });
 

--- a/test.js
+++ b/test.js
@@ -5,12 +5,12 @@ const hapi = require('hapi');
 const defer = require('p-defer');
 const plugin = require('./');
 
+const dsn = 'https://user@sentry.io/project';
+
 test.beforeEach(t => {
   delete global.__SENTRY__;
   t.context.server = new hapi.Server();
 });
-
-const dsn = 'https://53039209a22b4ec1bcc296a3c9fdecd6@sentry.io/4291';
 
 test('requires a dsn', async t => {
   const { server } = t.context;

--- a/test.js
+++ b/test.js
@@ -48,7 +48,7 @@ test('exposes a per-request scope', async t => {
   server.route({
     method: 'GET',
     path: '/',
-    handler (request) {
+    handler(request) {
       t.is(typeof request.sentryScope.setTag, 'function');
       return null;
     },

--- a/test.js
+++ b/test.js
@@ -48,7 +48,7 @@ test('exposes a per-request scope', async t => {
   server.route({
     method: 'GET',
     path: '/',
-    handler: (request) => {
+    handler (request) {
       t.is(typeof request.sentryScope.setTag, 'function');
       return null;
     },
@@ -73,7 +73,7 @@ test('captures request errors', async t => {
   server.route({
     method: 'GET',
     path: '/',
-    handler: () => {
+    handler() {
       throw new Error('Oh no!');
     },
   });
@@ -105,7 +105,7 @@ test('parses request metadata', async t => {
   server.route({
     method: 'GET',
     path: '/route',
-    handler: () => {
+    handler() {
       throw new Error('Oh no!');
     },
   });
@@ -137,7 +137,7 @@ test('sanitizes user info from auth', async t => {
 
   server.auth.scheme('mock', () => {
     return {
-      authenticate: (request, h) => {
+      authenticate(request, h) {
         return h.authenticated({
           credentials: {
             username: 'me',
@@ -154,7 +154,7 @@ test('sanitizes user info from auth', async t => {
   server.route({
     method: 'GET',
     path: '/',
-    handler: () => {
+    handler() {
       throw new Error('Oh no!');
     },
     config: {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,186 @@
+'use strict';
+
+const test = require('ava');
+const hapi = require('hapi');
+const defer = require('p-defer');
+const plugin = require('./');
+
+test.beforeEach(t => {
+  delete global.__SENTRY__;
+  t.context.server = new hapi.Server();
+});
+
+const dsn = 'https://53039209a22b4ec1bcc296a3c9fdecd6@sentry.io/4291';
+
+test('requires a dsn', async t => {
+  const { server } = t.context;
+  const err = await t.throwsAsync(async () => {
+    await server.register({
+      plugin,
+      options: {
+        client: {},
+      },
+    });
+  }, {
+    name: 'ValidationError',
+    message: /Invalid hapi-sentry options/,
+  });
+
+  t.deepEqual(err.details.map(d => d.message), [
+    '"dsn" is required',
+  ]);
+});
+
+test('exposes the sentry client', async t => {
+  const { server } = t.context;
+
+  await server.register({
+    plugin,
+    options: {
+      client: { dsn, beforeSend: (e) => e },
+    },
+  });
+
+  t.is(typeof server.plugins['hapi-sentry'].client.captureException, 'function');
+});
+
+test('exposes a per-request scope', async t => {
+  const { server } = t.context;
+
+  server.route({
+    method: 'GET',
+    path: '/',
+    handler: async (request) => {
+      t.is(typeof request.sentryScope.setTag, 'function');
+      return null;
+    },
+  });
+
+  await server.register({
+    plugin,
+    options: {
+      client: { dsn },
+    },
+  });
+
+  await server.inject({
+    method: 'GET',
+    url: '/',
+  });
+});
+
+test('captures request errors', async t => {
+  const { server } = t.context;
+
+  server.route({
+    method: 'GET',
+    path: '/',
+    handler: async () => {
+      throw new Error('Oh no!');
+    },
+  });
+
+  const deferred = defer();
+  await server.register({
+    plugin,
+    options: {
+      client: {
+        dsn,
+        beforeSend: deferred.resolve,
+      },
+    },
+  });
+
+  await server.inject({
+    method: 'GET',
+    url: '/',
+  });
+
+  const event = await deferred.promise;
+  t.is(event.message, 'Error: Oh no!');
+  t.is(event.level, 'error');
+});
+
+test('parses request metadata', async t => {
+  const { server } = t.context;
+
+  server.route({
+    method: 'GET',
+    path: '/route',
+    handler: async () => {
+      throw new Error('Oh no!');
+    },
+  });
+
+  const deferred = defer();
+  await server.register({
+    plugin,
+    options: {
+      client: {
+        dsn,
+        beforeSend: deferred.resolve,
+      },
+    },
+  });
+
+  await server.inject({
+    method: 'GET',
+    url: '/route',
+  });
+
+  const event = await deferred.promise;
+  const { request } = event;
+  t.is(request.method, 'GET');
+  t.is(typeof request.headers, 'object');
+  t.is(request.url, `http://${request.headers.host}/route`);
+});
+
+test('sanitizes user info from auth', async t => {
+  const { server } = t.context;
+
+  server.auth.scheme('mock', () => {
+    return {
+      authenticate: (request, h) => {
+        return h.authenticated({
+          credentials: {
+            username: 'me',
+            password: 'open sesame',
+            pw: 'os',
+            secret: 'abc123',
+          },
+        });
+      },
+    };
+  });
+  server.auth.strategy('mock', 'mock');
+
+  server.route({
+    method: 'GET',
+    path: '/',
+    handler: async () => {
+      throw new Error('Oh no!');
+    },
+    config: {
+      auth: 'mock',
+    },
+  });
+
+  const deferred = defer();
+  await server.register({
+    plugin,
+    options: {
+      client: {
+        dsn,
+        beforeSend: deferred.resolve,
+      },
+    },
+  });
+
+  await server.inject({
+    method: 'GET',
+    url: '/',
+  });
+
+  const event = await deferred.promise;
+  t.deepEqual(event.user, { username: 'me' });
+});

--- a/test.js
+++ b/test.js
@@ -14,14 +14,12 @@ const dsn = 'https://53039209a22b4ec1bcc296a3c9fdecd6@sentry.io/4291';
 
 test('requires a dsn', async t => {
   const { server } = t.context;
-  const err = await t.throwsAsync(async () => {
-    await server.register({
-      plugin,
-      options: {
-        client: {},
-      },
-    });
-  }, {
+  const err = await t.throwsAsync(() => server.register({
+    plugin,
+    options: {
+      client: {},
+    },
+  }), {
     name: 'ValidationError',
     message: /Invalid hapi-sentry options/,
   });
@@ -37,7 +35,7 @@ test('exposes the sentry client', async t => {
   await server.register({
     plugin,
     options: {
-      client: { dsn, beforeSend: (e) => e },
+      client: { dsn, beforeSend: e => e },
     },
   });
 
@@ -50,7 +48,7 @@ test('exposes a per-request scope', async t => {
   server.route({
     method: 'GET',
     path: '/',
-    handler: async (request) => {
+    handler: (request) => {
       t.is(typeof request.sentryScope.setTag, 'function');
       return null;
     },
@@ -75,7 +73,7 @@ test('captures request errors', async t => {
   server.route({
     method: 'GET',
     path: '/',
-    handler: async () => {
+    handler: () => {
       throw new Error('Oh no!');
     },
   });
@@ -107,7 +105,7 @@ test('parses request metadata', async t => {
   server.route({
     method: 'GET',
     path: '/route',
-    handler: async () => {
+    handler: () => {
       throw new Error('Oh no!');
     },
   });
@@ -128,8 +126,7 @@ test('parses request metadata', async t => {
     url: '/route',
   });
 
-  const event = await deferred.promise;
-  const { request } = event;
+  const { request } = await deferred.promise;
   t.is(request.method, 'GET');
   t.is(typeof request.headers, 'object');
   t.is(request.url, `http://${request.headers.host}/route`);
@@ -157,7 +154,7 @@ test('sanitizes user info from auth', async t => {
   server.route({
     method: 'GET',
     path: '/',
-    handler: async () => {
+    handler: () => {
       throw new Error('Oh no!');
     },
     config: {


### PR DESCRIPTION
Hi there, maintainer of [hapi-raven](https://github.com/bendrucker/hapi-raven) here! Someone asked about support for `@sentry/node` and I happened upon your package. I'd like to deprecate hapi-raven and direct users over here. I'd like to see this project reach 1.0 before I do that.

I've added tests here. I chose `ava` since I noticed you'd used it before on a project. They have some major changes coming up in a 1.0 so I figured the prerelease made the most sense.

I tried to focus on the major branches/features. Happy to come back and add more tests for the various options in a later PR. 