### PR TITLE
Use Github shorthand for "repository" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,7 @@
   "eslintConfig": {
     "extends": "@hydrant/eslint-config/modern"
   },
-  "repository": {
-    "type": "git",
-    "url": "git@github.com/hydra-newmedia/hapi-sentry.git"
-  },
+  "repository": "hydra-newmedia/hapi-sentry",
   "keywords": [
     "hapi",
     "sentry",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "eslintConfig": {
     "extends": "@hydrant/eslint-config/modern"
   },
-  "repository": "hydra-newmedia/hapi-sentry",
+  "repository": "github:hydra-newmedia/hapi-sentry",
   "keywords": [
     "hapi",
     "sentry",


### PR DESCRIPTION
I think the current formatting is preventing npm from displaying GitHub info in the package's sidebar, e.g.:

![](https://d.pr/i/bKSUQg+)

It would seem the SSH-style `git@` is not valid in `repository`. To confirm this, you can run `npm docs` locally. Against master, it opens up the package page on npm. Against this branch, it opens the GH repo at the readme.