### PR TITLE
Use `Hoek.applyToDefaults` instead of `Object.assign`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const { name, version } = require('./package.json');
 const schema = require('./schema');
 
+const Hoek = require('hoek');
 const Sentry = require('@sentry/node');
 const joi = require('joi');
 
@@ -61,7 +62,7 @@ exports.register = (server, options) => {
 
     // @sentry/node.captureEvent does not support scope parameter, if it's not from Sentry.Hub(?)
     Sentry.withScope(scope => { // thus use a temp scope and re-assign it
-      Object.assign(scope, request.sentryScope);
+      Hoek.applyToDefaults(scope, request.sentryScope);
       Sentry.captureEvent(sentryEvent);
     });
   });

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@sentry/node": "^4.2.4",
+    "hoek": "^6.1.2",
     "joi": "^14.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR fixes #11 by replacing `Object.assign` with `Hoek.applyToDefaults` in order to preserve the settings on the previously configured scope from plugin registration. The current implementation has the `tags` and `extra` fields on the scope overridden by the same empty fields of a new scope created for the request.