### PR TITLE
Allow custom client to be passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The plugin options, you can pass in while registering are the following:
 | `scope.tags.name`         | string       | The name of a tag                                                                                                            |
 | `scope.tags.value`        | any          | The value of a tag                                                                                                           |
 | `scope.extra`             | object       | An object of arbitrary format to be sent as extra data on every event                                                        |
-| `client`                  | object       | **required** Options to be passed to the [@sentry/node](https://www.npmjs.com/package/@sentry/node)s init function           |
+| `client`                  | object       | **required** A [@sentry/node](https://www.npmjs.com/package/@sentry/node) instance which was already initialized (using `Sentry.init`) OR an options object to be passed to an internally initialized [@sentry/node](https://www.npmjs.com/package/@sentry/node) (`client.dsn` is only required in the latter case) |
 | `client.dsn`              | string/false | **required** The Dsn used to connect to Sentry and identify the project. If false, the SDK will not send any data to Sentry. |
 | `client.debug`            | boolean      | Turn debug mode on/off                                                                                                       |
 | `client.release`          | string       | Tag events with the version/release identifier of your application                                                           |
@@ -47,7 +47,9 @@ the `scope` option is used to set up a global
 [`Scope`](http://getsentry.github.io/sentry-javascript/classes/hub.scope.html)
 for all events and the
 [`client`](http://getsentry.github.io/sentry-javascript/interfaces/node.nodeoptions.html) option
-is used to initialize the Sentry library.
+is used as a Sentry instance or to initialize an internally used Sentry instance.
+The internally used client (initialized in either way) is accessible through
+`server.plugins['hapi-sentry'].client`.
 
 ## Scope
 

--- a/index.js
+++ b/index.js
@@ -4,14 +4,18 @@ const { name, version } = require('./package.json');
 const schema = require('./schema');
 
 const Hoek = require('hoek');
-const Sentry = require('@sentry/node');
 const joi = require('joi');
 
 exports.register = (server, options) => {
   const opts = joi.attempt(options, schema, 'Invalid hapi-sentry options:');
 
-  // initialize sentry client
-  Sentry.init(opts.client);
+  let Sentry = opts.client;
+  // initialize own sentry client if none passed as option
+  if (opts.client.dsn) {
+    Sentry = require('@sentry/node');
+    Sentry.init(opts.client);
+  }
+
   // initialize global scope if set via plugin options
   if (opts.scope) {
     Sentry.configureScope(scope => {

--- a/schema.js
+++ b/schema.js
@@ -6,6 +6,33 @@ const joi = require('joi');
 const levels = Object.values(Severity).filter(level => typeof level === 'string')
   || ['fatal', 'error', 'warning', 'log', 'info', 'debug', 'critical'];
 
+const sentryClient = joi.object().keys({
+  configureScope: joi.func().minArity(1),
+  Scope: joi.func().required(),
+  Parsers: joi.object().keys({
+    parseError: joi.func().minArity(1).required(),
+  }).unknown().required(),
+  Handlers: joi.object().keys({
+    parseRequest: joi.func().minArity(2).required(),
+  }).unknown().required(),
+  withScope: joi.func().minArity(1).required(),
+  captureEvent: joi.func().minArity(1).required(),
+}).unknown();
+
+const sentryOptions = joi.object().keys({
+  dsn: joi.string().uri().allow(false).required(),
+  debug: joi.boolean(),
+  release: joi.string(),
+  environment: joi.string(),
+  sampleRate: joi.number().min(0).max(1),
+  maxBreadcrumbs: joi.number().integer(),
+  attachStacktrace: joi.any(),
+  sendDefaultPii: joi.boolean(),
+  serverName: joi.string(),
+  beforeSend: joi.func(),
+  beforeBreadcrumb: joi.func(),
+});
+
 module.exports = joi.object().keys({
   baseUri: joi.string().uri(),
   channels: joi.array().items(joi.string().only(levels)).single().default('error'),
@@ -18,17 +45,5 @@ module.exports = joi.object().keys({
     level: joi.string().only(levels),
     extra: joi.object(),
   }),
-  client: joi.object().keys({
-    dsn: joi.string().uri().allow(false).required(),
-    debug: joi.boolean(),
-    release: joi.string(),
-    environment: joi.string(),
-    sampleRate: joi.number().min(0).max(1),
-    maxBreadcrumbs: joi.number().integer(),
-    attachStacktrace: joi.any(),
-    sendDefaultPii: joi.boolean(),
-    serverName: joi.string(),
-    beforeSend: joi.func(),
-    beforeBreadcrumb: joi.func(),
-  }).required(),
+  client: joi.alternatives().try([sentryOptions, sentryClient]).required(),
 });


### PR DESCRIPTION
fixes #16 by allowing
> to pass Sentry instance to plugin

Ensures that the needed functions are present (by using a new joi schema), if a custom Sentry client is passed.

CC: @jardakotesovec