### PR TITLE
Use addEventProcessor for compatibility with sentry 4 and 5

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -13,7 +13,7 @@ const sentryClient = joi.object().keys({
     parseRequest: joi.func().minArity(2).required(),
   }).unknown().required(),
   withScope: joi.func().minArity(1).required(),
-  captureEvent: joi.func().minArity(1).required(),
+  captureException: joi.func().minArity(1).required(),
 }).unknown();
 
 const sentryOptions = joi.object().keys({

--- a/schema.js
+++ b/schema.js
@@ -9,9 +9,6 @@ const levels = Object.values(Severity).filter(level => typeof level === 'string'
 const sentryClient = joi.object().keys({
   configureScope: joi.func().minArity(1),
   Scope: joi.func().required(),
-  Parsers: joi.object().keys({
-    parseError: joi.func().minArity(1).required(),
-  }).unknown().required(),
   Handlers: joi.object().keys({
     parseRequest: joi.func().minArity(2).required(),
   }).unknown().required(),

--- a/test.js
+++ b/test.js
@@ -20,9 +20,9 @@ test('requires a dsn or a Scope (sentry opts vs. sentry client)', async t => {
       client: {},
     },
   }), {
-      name: 'ValidationError',
-      message: /Invalid hapi-sentry options/,
-    });
+    name: 'ValidationError',
+    message: /Invalid hapi-sentry options/,
+  });
 
   t.deepEqual(err.details.map(d => d.message), [
     '"dsn" is required',


### PR DESCRIPTION
Based on [example](https://github.com/getsentry/sentry-javascript/issues/1781#issuecomment-444510327) from sentry developer I used `addEventProcessor` to enrich the event.

If I don't miss something, this could be easy update which has compatibility with both sentry 4 and 5.