### PR TITLE
create domain per request, so hub per request is created

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ exports.register = (server, options) => {
       }
 
       // attach a new scope to each request for breadcrumbs/tags/extras/etc capturing
-      request.sentryScope = new Sentry.Scope();
+      request.sentryScope = Sentry.getCurrentHub().getScope();
 
       return h.continue;
     },

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ exports.register = (server, options) => {
       }
 
       // attach a new scope to each request for breadcrumbs/tags/extras/etc capturing
-      request.sentryScope = Sentry.getCurrentHub().getScope();
+      request.sentryScope = new Sentry.Scope();
 
       return h.continue;
     },

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   "dependencies": {
     "@hapi/hoek": "^9.0.2",
     "@hapi/joi": "^15.1.0",
-    "@sentry/node": "^5.4.3",
-    "delay": "^4.3.0"
+    "@sentry/node": "^5.4.3"
   },
   "devDependencies": {
     "@hapi/hapi": "^19.0.2",
     "@hydrant/eslint-config": "^2.1.3",
     "ava": "^2.1.0",
+    "delay": "^4.3.0",
     "eslint": "^6.0.1",
     "eslint-plugin-ava": "^9.0.0",
     "lint-staged": "^9.5.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "@hapi/hoek": "^9.0.2",
     "@hapi/joi": "^15.1.0",
-    "@sentry/node": "^5.4.3"
+    "@sentry/node": "^5.4.3",
+    "delay": "^4.3.0"
   },
   "devDependencies": {
     "@hapi/hapi": "^19.0.2",

--- a/schema.js
+++ b/schema.js
@@ -36,4 +36,5 @@ module.exports = joi.object().keys({
     joi.boolean(),
     joi.array().items(joi.string()),
   ).default(false),
+  useDomainPerRequest: joi.boolean().default(false),
 });

--- a/test.js
+++ b/test.js
@@ -242,6 +242,7 @@ test('collects breadcrumbs per domain', async t => {
   await server.register({
     plugin,
     options: {
+      useDomainPerRequest: true,
       client: {
         dsn,
         beforeSend(event) {

--- a/test.js
+++ b/test.js
@@ -120,31 +120,6 @@ test('exposes the sentry client', async t => {
   t.is(typeof server.plugins['hapi-sentry'].client.captureException, 'function');
 });
 
-test('exposes a per-request scope', async t => {
-  const { server } = t.context;
-
-  server.route({
-    method: 'GET',
-    path: '/',
-    handler(request) {
-      t.is(typeof request.sentryScope.setTag, 'function');
-      return null;
-    },
-  });
-
-  await server.register({
-    plugin,
-    options: {
-      client: { dsn },
-    },
-  });
-
-  await server.inject({
-    method: 'GET',
-    url: '/',
-  });
-});
-
 test('captures request errors', async t => {
   const { server } = t.context;
 

--- a/test.js
+++ b/test.js
@@ -83,6 +83,13 @@ test('uses a custom sentry client', async t => {
   const deferred = defer();
   const customSentry = {
     Scope: class Scope {},
+    getCurrentHub() {
+      return {
+        getScope() {
+          return {};
+        },
+      };
+    },
     // arity needed to pass joi validation
     Handlers: { parseRequest: (x, y) => { } }, // eslint-disable-line no-unused-vars
     withScope: cb => cb({ addEventProcessor: () => { } }),

--- a/test.js
+++ b/test.js
@@ -120,6 +120,31 @@ test('exposes the sentry client', async t => {
   t.is(typeof server.plugins['hapi-sentry'].client.captureException, 'function');
 });
 
+test('exposes a per-request scope', async t => {
+  const { server } = t.context;
+
+  server.route({
+    method: 'GET',
+    path: '/',
+    handler(request) {
+      t.is(typeof request.sentryScope.setTag, 'function');
+      return null;
+    },
+  });
+
+  await server.register({
+    plugin,
+    options: {
+      client: { dsn },
+    },
+  });
+
+  await server.inject({
+    method: 'GET',
+    url: '/',
+  });
+});
+
 test('captures request errors', async t => {
   const { server } = t.context;
 

--- a/test.js
+++ b/test.js
@@ -3,6 +3,8 @@
 const test = require('ava');
 const hapi = require('@hapi/hapi');
 const defer = require('p-defer');
+const delay = require('delay');
+
 const plugin = require('./');
 
 const dsn = 'https://user@sentry.io/project';
@@ -208,6 +210,82 @@ test('parses request metadata', async t => {
   t.is(request.method, 'GET');
   t.is(typeof request.headers, 'object');
   t.is(request.url, `http://${request.headers.host}/route`);
+});
+
+// sorry for console.log being the easiest way to set breadcrumbs
+test('collects breadcrumbs per domain', async t => {
+  const { server } = t.context;
+
+
+  server.route({
+    method: 'GET',
+    path: '/route1',
+    async handler() {
+      await delay(400);
+      clearInterval(interval);
+      throw new Error('Error 1');
+    },
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/route2',
+    async handler() {
+      await delay(200);
+      console.log('domain breadcrumb');
+      throw new Error('Error 2');
+    },
+  });
+
+  const deferred1 = defer();
+  const deferred2 = defer();
+  await server.register({
+    plugin,
+    options: {
+      client: {
+        dsn,
+        beforeSend(event) {
+          const { request } = event;
+          if (request.url === `http://${request.headers.host}/route1`) {
+            return deferred1.resolve(event);
+          }
+          return deferred2.resolve(event);
+        },
+      },
+    },
+  });
+
+  let n = 1;
+  const interval = setInterval(() => console.log(`global breadcrumb ${n++}`), 60);
+
+  await Promise.all([
+    server.inject({ method: 'GET', url: '/route1' }),
+    server.inject({ method: 'GET', url: '/route2' }),
+  ]);
+
+  // /route1 should not see local breadcrumb of /route2
+  const event1 = await deferred1.promise;
+  t.is(event1.exception.values[0].value, 'Error 1');
+  const event1Breadcrumbs = event1.breadcrumbs.map(b => b.message);
+  const breadcrumbs1 = [
+    // /route2 consumes number 1 to 3, leaves 4 to 6 for /route1
+    'global breadcrumb 4',
+    'global breadcrumb 5',
+    'global breadcrumb 6',
+  ];
+  t.true(breadcrumbs1.every(b => event1Breadcrumbs.includes(b)));
+
+  const event2 = await deferred2.promise;
+  t.is(event2.exception.values[0].value, 'Error 2');
+  const event2Breadcrumbs = event2.breadcrumbs.map(b => b.message);
+  const breadcrumbs2 = [
+    'global breadcrumb 1',
+    'global breadcrumb 2',
+    'global breadcrumb 3',
+    'domain breadcrumb',
+  ];
+  t.true(event2Breadcrumbs.some(b => b.includes('[DEP0097]'))); // yeah, domains are deprecated
+  t.true(breadcrumbs2.every(b => event2Breadcrumbs.includes(b)));
 });
 
 test('sanitizes user info from auth', async t => {


### PR DESCRIPTION
I suspect that creating `new Scope()` does not do anything.. its just empty object and it will stay empty. You can try - no breadcrumbs get recorded there.

After bit digging, I think only way to isolate requests is to have hub per request, which is saved in domain. This is pretty much what express middleware [does](https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/handlers.ts#L246). 

If you look at the [getCurrentHub](https://github.com/getsentry/sentry-javascript/blob/master/packages/hub/src/hub.ts#L393) it creates new hub in domain if there is active domain. Otherwise it uses one global hub. 

Using this would also add option to add some context anywhere within request lifecycle with 
```
Sentry.configureScope(scope => {
  scope.setTag('key', 'value');
});
```

All these global functions like `configureScope` or `withScope` they get hub [internally](https://github.com/getsentry/sentry-javascript/blob/master/packages/minimal/src/index.ts#L9) via `getCurrentHub` which gets the current hub from active domain, therefore should be scoped to the request.

I will do some testing sometime soon, but interested in your feedback. This code is mainly just to get point across for now.

Hi @kamilogorek if you would have few minutes just to glance over this PR if it makes sense? It would be super helpful :-) Just trying to make the hapi integration right.
