### PR TITLE
feat: migrate to @hapi and newest sentry

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@
 const { name, version } = require('./package.json');
 const schema = require('./schema');
 
-const Hoek = require('hoek');
-const joi = require('joi');
+const Hoek = require('@hapi/hoek');
+const joi = require('@hapi/joi');
 
 exports.register = (server, options) => {
   const opts = joi.attempt(options, schema, 'Invalid hapi-sentry options:');

--- a/package.json
+++ b/package.json
@@ -27,20 +27,20 @@
   "author": "Christian Hotz <hotz@hydra-newmedia.com>",
   "license": "MIT",
   "peerDependencies": {
-    "hapi": ">=17"
+    "@hapi/hapi": ">=18"
   },
   "dependencies": {
-    "@sentry/node": "^4.2.4",
-    "hoek": "^6.1.2",
-    "joi": "^14.0.4"
+    "@sentry/node": "^5.4.3",
+    "@hapi/hoek": "^8.0.1",
+    "@hapi/joi": "^15.1.0"
   },
   "devDependencies": {
-    "@hydrant/eslint-config": "^2.0.1",
-    "ava": "^1.0.0-rc.2",
-    "eslint": "^5.8.0",
-    "eslint-plugin-ava": "^5.1.1",
-    "hapi": "^17.7.0",
-    "lint-staged": "^8.0.4",
-    "p-defer": "^1.0.0"
+    "@hydrant/eslint-config": "^2.1.0",
+    "ava": "^2.1.0",
+    "eslint": "^6.0.1",
+    "eslint-plugin-ava": "^7.1.0",
+    "@hapi/hapi": "^18.3.1",
+    "lint-staged": "^8.2.1",
+    "p-defer": "^3.0.0"
   }
 }

--- a/schema.js
+++ b/schema.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Severity } = require('@sentry/node');
-const joi = require('joi');
+const joi = require('@hapi/joi');
 
 const levels = Object.values(Severity).filter(level => typeof level === 'string')
   || ['fatal', 'error', 'warning', 'log', 'info', 'debug', 'critical'];

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const test = require('ava');
-const hapi = require('hapi');
+const hapi = require('@hapi/hapi');
 const defer = require('p-defer');
 const plugin = require('./');
 
@@ -174,8 +174,8 @@ test('captures request errors', async t => {
   });
 
   const event = await deferred.promise;
-  t.is(event.message, 'Error: Oh no!');
-  t.is(event.level, 'error');
+  t.is(event.exception.values[0].value, 'Oh no!');
+  t.is(event.exception.values[0].type, 'Error');
 });
 
 test('parses request metadata', async t => {


### PR DESCRIPTION
This commit migrates all hapi packages to their
new @hapi equivalents and updates tests to work
with latest sentry