### PR TITLE
Add support for events on 'app' channel and 'log' with 'error' tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The plugin options, you can pass in while registering are the following:
 | `client.serverName`       | string       | Overwrite the server name (device name)                                                                                      |
 | `client.beforeSend`       | func         | A callback invoked during event submission, allowing to optionally modify the event before it is sent to Sentry              |
 | `client.beforeBreadcrumb` | func         | A callback invoked when adding a breadcrumb, allowing to optionally modify it before adding it to future events.             |
-| `catchLogErrors` | boolean/array | Whether or not to capture errors logged via `server.log` or `request.log`. Events must contain an `'error'` tag or match one of the specified tags and pass an `Error` instance as data. Default: `false` |
+| `catchLogErrors` | boolean/array | Whether or not to capture errors logged via `server.log` or `request.log`. Events must contain one `['error', 'fatal', 'fail']` tags or match one of the specified tags and pass an `Error` instance as data. Default: `false` |
 
 The `baseUri` option is used internally to get a correct URL in sentry issues.
 The `scope` option is used to set up a global

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ request error logging to [Sentry](https://sentry.io/).
 Use the hapi plugin like this:
 ```JavaScript
 const server = hapi.server();
-await server.register({ 
-  plugin: require('hapi-sentry'), 
+await server.register({
+  plugin: require('hapi-sentry'),
   options: {
     client: { dsn: 'dsn-here' },
   },
@@ -45,6 +45,7 @@ The plugin options, you can pass in while registering are the following:
 | `client.serverName`       | string       | Overwrite the server name (device name)                                                                                      |
 | `client.beforeSend`       | func         | A callback invoked during event submission, allowing to optionally modify the event before it is sent to Sentry              |
 | `client.beforeBreadcrumb` | func         | A callback invoked when adding a breadcrumb, allowing to optionally modify it before adding it to future events.             |
+| `catchLogErrors` | boolean | Whether or not to capture errors logged via `server.log` or `request.log`. Events must contain an `'error'` tag and pass an `Error` instance as data. Default: `false` |
 
 The `baseUri` option is used internally to get a correct URL in sentry issues.
 The `scope` option is used to set up a global

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The plugin options, you can pass in while registering are the following:
 | `client.serverName`       | string       | Overwrite the server name (device name)                                                                                      |
 | `client.beforeSend`       | func         | A callback invoked during event submission, allowing to optionally modify the event before it is sent to Sentry              |
 | `client.beforeBreadcrumb` | func         | A callback invoked when adding a breadcrumb, allowing to optionally modify it before adding it to future events.             |
-| `catchLogErrors` | boolean | Whether or not to capture errors logged via `server.log` or `request.log`. Events must contain an `'error'` tag and pass an `Error` instance as data. Default: `false` |
+| `catchLogErrors` | boolean/array | Whether or not to capture errors logged via `server.log` or `request.log`. Events must contain an `'error'` tag or match one of the specified tags and pass an `Error` instance as data. Default: `false` |
 
 The `baseUri` option is used internally to get a correct URL in sentry issues.
 The `scope` option is used to set up a global

--- a/README.md
+++ b/README.md
@@ -25,27 +25,27 @@ await server.register({
 
 The plugin options, you can pass in while registering are the following:
 
-| property                  | type         | description                                                                                                                  |
-|:--------------------------|:-------------|:-----------------------------------------------------------------------------------------------------------------------------|
-| `baseUri`                 | string       | [uri](https://github.com/hapijs/joi/blob/master/API.md#stringurioptions) to be used as base for captured urls                |
-| `trackUser`               | boolean      | Whether or not to track the user via the per-request scope. Default: `true`                                                  |
-| `scope.tags`              | object       | An array of tags to be sent with every event                                                                                 |
-| `scope.tags.name`         | string       | The name of a tag                                                                                                            |
-| `scope.tags.value`        | any          | The value of a tag                                                                                                           |
-| `scope.extra`             | object       | An object of arbitrary format to be sent as extra data on every event                                                        |
-| `client`                  | object       | **required** A [@sentry/node](https://www.npmjs.com/package/@sentry/node) instance which was already initialized (using `Sentry.init`) OR an options object to be passed to an internally initialized [@sentry/node](https://www.npmjs.com/package/@sentry/node) (`client.dsn` is only required in the latter case) |
-| `client.dsn`              | string/false | **required** The Dsn used to connect to Sentry and identify the project. If false, the SDK will not send any data to Sentry. |
-| `client.debug`            | boolean      | Turn debug mode on/off                                                                                                       |
-| `client.release`          | string       | Tag events with the version/release identifier of your application                                                           |
-| `client.environment`      | string       | The current environment of your application (e.g. `'production'`)                                                            |
-| `client.sampleRate`       | number       | A global sample rate to apply to all events (0 - 1)                                                                          |
-| `client.maxBreadcrumbs`   | number       | The maximum number of breadcrumbs sent with events. Default: `100`                                                           |
-| `client.attachStacktrace` | any          | Attaches stacktraces to pure capture message / log integrations                                                              |
-| `client.sendDefaultPii`   | boolean      | If this flag is enabled, certain personally identifiable information is added by active integrations                         |
-| `client.serverName`       | string       | Overwrite the server name (device name)                                                                                      |
-| `client.beforeSend`       | func         | A callback invoked during event submission, allowing to optionally modify the event before it is sent to Sentry              |
-| `client.beforeBreadcrumb` | func         | A callback invoked when adding a breadcrumb, allowing to optionally modify it before adding it to future events.             |
-| `catchLogErrors` | boolean/array | Whether or not to capture errors logged via `server.log` or `request.log`. Events must contain one `['error', 'fatal', 'fail']` tags or match one of the specified tags and pass an `Error` instance as data. Default: `false` |
+| property                  | type          | description                                                                                                                  |
+|:--------------------------|:--------------|:-----------------------------------------------------------------------------------------------------------------------------|
+| `baseUri`                 | string        | [uri](https://github.com/hapijs/joi/blob/master/API.md#stringurioptions) to be used as base for captured urls                |
+| `trackUser`               | boolean       | Whether or not to track the user via the per-request scope. Default: `true`                                                  |
+| `scope.tags`              | object        | An array of tags to be sent with every event                                                                                 |
+| `scope.tags.name`         | string        | The name of a tag                                                                                                            |
+| `scope.tags.value`        | any           | The value of a tag                                                                                                           |
+| `scope.extra`             | object        | An object of arbitrary format to be sent as extra data on every event                                                        |
+| `client`                  | object        | **required** A [@sentry/node](https://www.npmjs.com/package/@sentry/node) instance which was already initialized (using `Sentry.init`) OR an options object to be passed to an internally initialized [@sentry/node](https://www.npmjs.com/package/@sentry/node) (`client.dsn` is only required in the latter case) |
+| `client.dsn`              | string/false  | **required** The Dsn used to connect to Sentry and identify the project. If false, the SDK will not send any data to Sentry. |
+| `client.debug`            | boolean       | Turn debug mode on/off                                                                                                       |
+| `client.release`          | string        | Tag events with the version/release identifier of your application                                                           |
+| `client.environment`      | string        | The current environment of your application (e.g. `'production'`)                                                            |
+| `client.sampleRate`       | number        | A global sample rate to apply to all events (0 - 1)                                                                          |
+| `client.maxBreadcrumbs`   | number        | The maximum number of breadcrumbs sent with events. Default: `100`                                                           |
+| `client.attachStacktrace` | any           | Attaches stacktraces to pure capture message / log integrations                                                              |
+| `client.sendDefaultPii`   | boolean       | If this flag is enabled, certain personally identifiable information is added by active integrations                         |
+| `client.serverName`       | string        | Overwrite the server name (device name)                                                                                      |
+| `client.beforeSend`       | func          | A callback invoked during event submission, allowing to optionally modify the event before it is sent to Sentry              |
+| `client.beforeBreadcrumb` | func          | A callback invoked when adding a breadcrumb, allowing to optionally modify it before adding it to future events.             |
+| `catchLogErrors`          | boolean/array | Handles [capturing server.log and request.log events](#capturing-serverlog-and-requestlog-events). Default: `false`          |
 
 The `baseUri` option is used internally to get a correct URL in sentry issues.
 The `scope` option is used to set up a global
@@ -90,6 +90,20 @@ server.route({
   },
 });
 ```
+
+## Capturing server.log and request.log events
+
+You can enable capturing of `request.log` and `server.log` events using the `catchLogErrors` option.
+All events which are `Error` objects and are tagged by one of `['error', 'fatal', 'fail']` are
+automatically being tracked when `catchLogErrors` is set to `true`,  e.g.:
+
+```js
+request.log(['error', 'foo'], new Error('Oh no!'));
+server.log(['error', 'foo'], new Error('No no!'));
+```
+
+The considered tags can be changed by setting `catchLogErrors` to a custom array of tags like
+`['error', 'warn', 'failure']`.
 
 ## Capturing the request body
 

--- a/index.js
+++ b/index.js
@@ -40,7 +40,8 @@ exports.register = (server, options) => {
 
   // get request errors to capture them with sentry
   server.events.on({ name: 'request', channels: ['error', 'app'] }, (request, event, tags) => {
-    if (event.channel === 'app' && (!tags.error || !event.error)) {
+    if (event.channel === 'app' &&
+      !(opts.catchLogErrors && tags.error && event.error)) {
       return;
     }
 
@@ -76,7 +77,7 @@ exports.register = (server, options) => {
   });
 
   server.events.on('log', (event, tags) => {
-    if (!tags.error || !event.error) {
+    if (!(opts.catchLogErrors && tags.error && event.error)) {
       return;
     }
 

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ exports.register = (server, options) => {
 
   // get request errors to capture them with sentry
   server.events.on({ name: 'request', channels: ['error', 'app'] }, (request, event, tags) => {
-    if (event.channel === 'app' && !tags.error) {
+    if (event.channel === 'app' && (!tags.error || !event.error)) {
       return;
     }
 
@@ -76,7 +76,7 @@ exports.register = (server, options) => {
   });
 
   server.events.on('log', (event, tags) =>  {
-    if (!tags.error) {
+    if (!tags.error || !event.error) {
       return;
     }
 

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ exports.register = (server, options) => {
     });
   });
 
-  server.events.on('log', (event, tags) =>  {
+  server.events.on('log', (event, tags) => {
     if (!tags.error || !event.error) {
       return;
     }

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ exports.register = (server, options) => {
   function shouldIgnoreEvent(event) {
     const match = catchLogErrors &&
       event.error &&
-      errorTags.reduce((cond, tag) => cond || event.tags.includes(tag), false)
+      errorTags.reduce((cond, tag) => cond || event.tags.includes(tag), false);
 
     return event.channel === 'app' && !match;
   }

--- a/schema.js
+++ b/schema.js
@@ -32,5 +32,8 @@ module.exports = joi.object().keys({
     extra: joi.object(),
   }),
   client: joi.alternatives().try([sentryOptions, sentryClient]).required(),
-  catchLogErrors: joi.boolean().default(false),
+  catchLogErrors: joi.alternatives().try(
+    joi.boolean(),
+    joi.array().items(joi.string()),
+  ).default(false),
 });

--- a/schema.js
+++ b/schema.js
@@ -32,4 +32,5 @@ module.exports = joi.object().keys({
     extra: joi.object(),
   }),
   client: joi.alternatives().try([sentryOptions, sentryClient]).required(),
+  catchLogErrors: joi.boolean().default(false),
 });

--- a/test.js
+++ b/test.js
@@ -260,7 +260,7 @@ test('sanitizes user info from auth', async t => {
   t.deepEqual(event.user, { username: 'me' });
 });
 
-test("process 'app' channel events with 'error' tag", async t => {
+test('process \'app\' channel events with \'error\' tag', async t => {
   const { server } = t.context;
 
   server.route({
@@ -293,13 +293,13 @@ test("process 'app' channel events with 'error' tag", async t => {
   t.is(event.exception.values[0].type, 'Error');
 });
 
-test("process 'log' events with 'error' tag", async t => {
+test('process \'log\' events with \'error\' tag', async t => {
   const { server } = t.context;
 
   server.route({
     method: 'GET',
     path: '/route',
-    handler(request) {
+    handler() {
       server.log(['error', 'foo'], new Error('Oh no!'));
       return null;
     },

--- a/test.js
+++ b/test.js
@@ -280,6 +280,7 @@ test('process \'app\' channel events with \'error\' tag', async t => {
         dsn,
         beforeSend: deferred.resolve,
       },
+      catchLogErrors: true,
     },
   });
 
@@ -313,6 +314,7 @@ test('process \'log\' events with \'error\' tag', async t => {
         dsn,
         beforeSend: deferred.resolve,
       },
+      catchLogErrors: true,
     },
   });
 

--- a/test.js
+++ b/test.js
@@ -259,3 +259,36 @@ test('sanitizes user info from auth', async t => {
   const event = await deferred.promise;
   t.deepEqual(event.user, { username: 'me' });
 });
+
+test("process events on 'app' channel with 'error' tag", async t => {
+  const { server } = t.context;
+
+  server.route({
+    method: 'GET',
+    path: '/route',
+    handler(request) {
+      request.log(['error', 'foo'], new Error('Oh no!'));
+      return null;
+    },
+  });
+
+  const deferred = defer();
+  await server.register({
+    plugin,
+    options: {
+      client: {
+        dsn,
+        beforeSend: deferred.resolve,
+      },
+    },
+  });
+
+  await server.inject({
+    method: 'GET',
+    url: '/route',
+  });
+
+  const event = await deferred.promise;
+  t.is(event.exception.values[0].value, 'Oh no!');
+  t.is(event.exception.values[0].type, 'Error');
+});


### PR DESCRIPTION
Hello, I had to add support for this and I wondered if you'd consider merging it.

This change adds support for capturing `request` and `server` log events containing `'error'` tag and an `Error` object. e.g.:

- `request.log(['error', 'foo'], new Error('Oh no!'));`
- `server.log(['error', 'foo'], new Error('Oh no!'));`
