### PR TITLE
Update for Hapi v20

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The plugin options, you can pass in while registering are the following:
 
 | property                  | type          | description                                                                                                                  |
 |:--------------------------|:--------------|:-----------------------------------------------------------------------------------------------------------------------------|
-| `baseUri`                 | string        | [uri](https://github.com/hapijs/joi/blob/master/API.md#stringurioptions) to be used as base for captured urls                |
+| `baseUri`                 | string        | [uri](https://github.com/sideway/joi/blob/master/API.md#stringurioptions) to be used as base for captured urls                |
 | `scope.tags`              | object        | An array of tags to be sent with every event                                                                                 |
 | `scope.tags.name`         | string        | The name of a tag                                                                                                            |
 | `scope.tags.value`        | any           | The value of a tag                                                                                                           |

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const { name, version } = require('./package.json');
 const schema = require('./schema');
 
 const Hoek = require('@hapi/hoek');
-const joi = require('@hapi/joi');
+const joi = require('joi');
 const domain = require('domain');
 
 exports.register = (server, options) => {

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   "author": "Christian Hotz <hotz@hydra-newmedia.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@hapi/hapi": "^19.0.0"
+    "@hapi/hapi": "^19.0.0 || ^20.0.0"
   },
   "dependencies": {
     "@hapi/hoek": "^9.0.2",
-    "@hapi/joi": "^17.1.0",
-    "@sentry/node": "^5.4.3"
+    "@sentry/node": "^5.4.3",
+    "joi": "^17.2.0"
   },
   "devDependencies": {
     "@hapi/hapi": "19.1.1",

--- a/schema.js
+++ b/schema.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Severity } = require('@sentry/node');
-const joi = require('@hapi/joi');
+const joi = require('joi');
 
 const levels = Object.values(Severity).filter(level => typeof level === 'string')
   || ['fatal', 'error', 'warning', 'log', 'info', 'debug', 'critical'];


### PR DESCRIPTION
As described at hapi/hapi#4138 and sideway/joi#2411, Hapi v20 has no breaking code changes, and Joi is no longer part of the Hapi organization.