### PR TITLE
Introduce true Request Separation using domains

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 const domain = require('domain'); // eslint-disable-line node/no-deprecated-api
 const joi = require('joi');
 const shimmer = require('shimmer');
+const eventsIntercept = require('events-intercept');
 
 const { name, version } = require('./package.json');
 const schema = require('./schema');
@@ -33,16 +34,24 @@ exports.register = (server, options) => {
   server.expose('client', Sentry);
 
   // Set up request interceptor for creating and destroying a domain on each request
-  // It'll wrap the request handler returned by the _dispatch function in HAPI core
-  // allowing it to create the domain before any of HAPIs processing starts
-  // thus allowing us to use the normal HAPI extensions to add context to Sentry scopes
-  // https://github.com/hapijs/hapi/blob/c95985e225fa09c4b640a887ccb4be46dbe265bc/lib/core.js#L507-L538
+  // It'll intercept events emitted by the Hapi `server.listener` which is a `http.Server`
+  // eventEmitter. This allows us to to create a domain before any of HAPIs processing starts
+  // thus allowing us to use the normal HAPI extensions to add context to Sentry scopes.
   function interceptor(next, req, res, ...args) {
     const local = domain.create(); // Create domain to hold context for request
     local.add(req);
     local.add(res);
 
-    let rtn;
+    // The interceptor will call the original function being either intercepted or wrapped
+    // that function should only ever return `undefined` but it's good practice to always
+    // capture that value and pass it back upstream, just in case our original function
+    // decides to start returning something other than `undefined` in the future.
+    //
+    // We need to declare it here, because the body of our interceptor runs inside
+    // an anonymous function wrapped by the `domain` run function. So this declaration
+    // ensures we can pull the value out of anonymous function's scope and actually
+    // return it.
+    let originalFuncReturnValue;
 
     local.run(() => { // Create new scope for request
       const currentHub = Sentry.getCurrentHub();
@@ -63,24 +72,66 @@ exports.register = (server, options) => {
           return sentryEvent;
         });
       });
-      rtn = next.apply(this, [req, res].concat(args));
+
+      // Capture return value here
+      originalFuncReturnValue = next.apply(this, [null, req, res].concat(args));
     });
 
-    return rtn;
+    return originalFuncReturnValue;
   }
 
-  // Wrap HAPI core _dispatch function. This function is primary entry point into HAPI for an
-  // external request. It's a factory that returns Node request handlers
+  // Wrap HAPI core _dispatch function. It's a factory that returns Node request listeners.
+  // We need to wrap it to make Hapi's `server.inject()` API work, but the wrapped function
+  // isn't involved in normal request handling.
+  //
+  // Normal requests are intercepted before they get to the `_dispatch` function, and never pass
+  // through our wrapped `_dispatch` function because Hapi uses `_dispatch` function and binds
+  // the created request listeners to the eventEmitter before we have an opportunity to wrap it.
+  //
   // https://github.com/hapijs/hapi/blob/c95985e225fa09c4b640a887ccb4be46dbe265bc/lib/core.js#L505-L539
-  if (!server._core._dispatch.__wrapped) {
+  //
+  // We only wrap if it hasn't already been wrapped (as indicated by `__wrapped`)
+  if (server._core && server._core._dispatch && !server._core._dispatch.__wrapped) {
     shimmer.wrap(server._core, '_dispatch', function (original) { // eslint-disable-line
+
+      // Wrapper for `_dispatch`
       return function _dispatch_wrapped(...dispatchArgs) { // eslint-disable-line
+        // Call the original `_dispatch` function to get a request listener because we actually want
+        // to intercept calls to the listener, rather than to `_dispatch` itself.
         const listener = original.apply(this, dispatchArgs);
 
-        return interceptor.bind(this, listener);
+        // Create a `next` function compatible with our interceptor function.
+        // It simply extracts the err value and throws it away, passing the remaining arguments to
+        // the original listener.
+        // It safe to do this because our interceptor function never calls `next` with an error, it
+        // always passes null. Doing so because it's a requirement of the `eventInterceptor` library
+        function next(err, ...args) {
+          listener.apply(this, args);
+        }
+
+        // Bind the interceptor, to `this` and `next` so when the interceptor is called with a
+        // request it runs in the context that Hapi intended it to. Additionally the first argument
+        // to the interceptor will be `next`, followed by whatever arguments the original caller
+        // passes.
+        return interceptor.bind(this, next);
       };
     });
   }
+
+  // Setup listener interceptors so we can intercept inbound requests from Node, needed
+  // because we can't patch HAPI before it sets up listeners
+  eventsIntercept.patch(server.listener);
+  server.listener.intercept('request', function _requestInterceptor(...args) {
+    // Rearrange incoming arguments. The `eventsInterceptor` sends us arguments in the following
+    // order: `func(origArg1, ..., origArgN, nextFunc)` but we want the `nextFunc` to be first
+
+    // `func(origArg1, ..., origArgN, nextFunc)` -> `func(nextFunc, origArg1, ..., origArgN)`
+    interceptor.apply(this, [args[args.length - 1], ...args.slice(0, -1)]);
+  });
+  server.listener.intercept('checkContinue', function _checkContinueInterceptor(...args) {
+    // `func(origArg1, ..., origArgN, nextFunc)` -> `func(nextFunc, origArg1, ..., origArgN)`
+    interceptor.apply(this, [args[args.length - 1], ...args.slice(0, -1)]);
+  });
 
   server.ext([
     {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,13 @@
     }
   },
   "eslintConfig": {
+    "env": {
+      "node": true
+    },
     "extends": [
       "airbnb-base",
-      "plugin:ava/recommended"
+      "plugin:ava/recommended",
+      "plugin:node/recommended"
     ],
     "parserOptions": {
       "sourceType": "script"
@@ -31,6 +35,9 @@
       "no-param-reassign": 0
     }
   },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "repository": "github:hydra-newmedia/hapi-sentry",
   "keywords": [
     "hapi",
@@ -40,21 +47,21 @@
   "author": "Christian Hotz <hotz@hydra-newmedia.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@hapi/hapi": "^19.0.0 || ^20.0.0"
+    "@hapi/hapi": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0"
   },
   "dependencies": {
-    "@hapi/hoek": "^9.1.0",
     "@sentry/node": "^6.2.2",
-    "events-intercept": "^2.0.0",
-    "joi": "^17.2.1"
+    "joi": "^17.2.1",
+    "shimmer": "^1.2.1"
   },
   "devDependencies": {
     "@hapi/hapi": "^20.0.0",
     "ava": "^3.15.0",
-    "eslint": "^7.22.0",
+    "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-ava": "^12.0.0",
     "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-node": "^11.1.0",
     "husky": "^4.3.0",
     "lint-staged": "^11.0.0",
     "p-defer": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@hapi/hoek": "^9.1.0",
     "@sentry/node": "^6.2.2",
+    "events-intercept": "^2.0.0",
     "joi": "^17.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,11 +51,13 @@
   },
   "dependencies": {
     "@sentry/node": "^6.2.2",
+    "events-intercept": "^2.0.0",
     "joi": "^17.2.1",
     "shimmer": "^1.2.1"
   },
   "devDependencies": {
     "@hapi/hapi": "^20.0.0",
+    "@hapi/shot": "^5.0.5",
     "ava": "^3.15.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",

--- a/test.js
+++ b/test.js
@@ -1,8 +1,13 @@
+/* eslint-disable max-classes-per-file */
+/* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
+/* eslint-disable node/no-unpublished-require */
+
 'use strict';
 
 const test = require('ava');
 const hapi = require('@hapi/hapi');
 const defer = require('p-defer');
+const Sentry = require('@sentry/node');
 
 const plugin = require('.');
 
@@ -10,6 +15,12 @@ const dsn = 'https://examplePublicKey@o0.ingest.sentry.io/0';
 
 test.beforeEach(t => {
   delete global.__SENTRY__;
+  // Sentry does some patching to the __SENTRY__ global on import
+  // we need that patching to be reapplied after deleting the global
+  // or domain stuff doesn't work. To do this we first remove sentry
+  // from the node module cache, then re-import.
+  delete require.cache[require.resolve('@sentry/node')];
+  require('@sentry/node'); // eslint-disable-line global-require
   t.context.server = new hapi.Server();
 });
 
@@ -55,6 +66,7 @@ test('allows deactivating capture (opts.dsn to be false)', async t => {
   await server.inject({
     method: 'GET',
     url: '/',
+    payload: t.title,
   });
 
   let eventCaptured = false;
@@ -82,16 +94,19 @@ test('uses a custom sentry client', async t => {
 
   const deferred = defer();
   const customSentry = {
-    Scope: class Scope {},
+    Scope: class Scope { },
     getCurrentHub() {
       return {
         getScope() {
           return {};
         },
+        configureScope() {
+          return null;
+        },
       };
     },
     // arity needed to pass joi validation
-    Handlers: { parseRequest: (x, y) => { } }, // eslint-disable-line no-unused-vars
+    Handlers: { parseRequest: (_x, _y) => { } }, // eslint-disable-line no-unused-vars
     withScope: cb => cb({ addEventProcessor: () => { } }),
     captureException: deferred.resolve,
   };
@@ -110,6 +125,7 @@ test('uses a custom sentry client', async t => {
   await server.inject({
     method: 'GET',
     url: '/route',
+    payload: t.title,
   });
 
   const event = await deferred.promise;
@@ -151,6 +167,7 @@ test('exposes a per-request scope', async t => {
   await server.inject({
     method: 'GET',
     url: '/',
+    payload: t.title,
   });
 });
 
@@ -179,6 +196,7 @@ test('captures request errors', async t => {
   await server.inject({
     method: 'GET',
     url: '/',
+    payload: t.title,
   });
 
   const event = await deferred.promise;
@@ -211,6 +229,7 @@ test('parses request metadata', async t => {
   await server.inject({
     method: 'GET',
     url: '/route',
+    payload: t.title,
   });
 
   const { request } = await deferred.promise;
@@ -223,7 +242,7 @@ test('sanitizes user info from auth', async t => {
   const { server } = t.context;
 
   server.auth.scheme('mock', () => ({
-    authenticate(request, h) {
+    authenticate(_request, h) {
       return h.authenticated({
         credentials: {
           username: 'me',
@@ -261,6 +280,7 @@ test('sanitizes user info from auth', async t => {
   await server.inject({
     method: 'GET',
     url: '/',
+    payload: t.title,
   });
 
   const event = await deferred.promise;
@@ -294,6 +314,7 @@ test('process \'app\' channel events with default tags', async t => {
   await server.inject({
     method: 'GET',
     url: '/route',
+    payload: t.title,
   });
 
   const event = await deferred.promise;
@@ -328,6 +349,7 @@ test('process \'app\' channel events with `catchLogErrors` tags', async t => {
   await server.inject({
     method: 'GET',
     url: '/route',
+    payload: t.title,
   });
 
   const event = await deferred.promise;
@@ -362,6 +384,7 @@ test('process \'log\' events with default tags', async t => {
   await server.inject({
     method: 'GET',
     url: '/route',
+    payload: t.title,
   });
 
   const event = await deferred.promise;
@@ -396,9 +419,125 @@ test('process \'log\' events with `catchLogErrors` tags', async t => {
   await server.inject({
     method: 'GET',
     url: '/route',
+    payload: t.title,
   });
 
   const event = await deferred.promise;
   t.is(event.exception.values[0].value, 'Oh no!');
   t.is(event.exception.values[0].type, 'Error');
+});
+
+test('request scope separation', async t => {
+  const { server } = t.context;
+
+  let remaining = 3;
+  const deferred = defer();
+
+  class DummyTransport {
+    // eslint-disable-next-line class-methods-use-this
+    sendEvent() {
+      remaining -= 1;
+
+      if (remaining === 0) {
+        deferred.resolve();
+      }
+
+      return Promise.resolve({
+        status: 'success',
+      });
+    }
+  }
+
+  await server.register({
+    plugin,
+    options: {
+      client: {
+        dsn,
+        transport: DummyTransport,
+        beforeSend: (event) => {
+          if (event.transaction === 'GET /one') {
+            t.deepEqual(event.tags,
+              {
+                globalTag: 'global',
+                oneTag: '👋',
+              });
+          } else if (event.transaction === 'GET /two') {
+            t.deepEqual(event.tags,
+              {
+                globalTag: 'global',
+                twoTag: '👋',
+              });
+          } else if (event.transaction === 'GET /three') {
+            t.deepEqual(event.tags,
+              {
+                globalTag: 'global',
+                threeTag: '👋',
+              });
+          } else {
+            t.fail(`Unknown transaction ${event.transaction}`);
+          }
+          return event;
+        },
+      },
+    },
+  });
+
+  Sentry.configureScope(scope => {
+    scope.setTag('globalTag', 'global');
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/one',
+    handler() {
+      Sentry.configureScope(scope => {
+        scope.setTag('oneTag', '👋');
+      });
+
+      throw new Error('one');
+    },
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/two',
+    handler() {
+      Sentry.configureScope(scope => {
+        scope.setTag('twoTag', '👋');
+      });
+
+      throw new Error('two');
+    },
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/three',
+    handler() {
+      Sentry.configureScope(scope => {
+        scope.setTag('threeTag', '👋');
+      });
+
+      throw new Error('three');
+    },
+  });
+
+  await Promise.all([
+    server.inject({
+      method: 'GET',
+      url: '/one',
+      payload: t.title,
+    }),
+    server.inject({
+      method: 'GET',
+      url: '/two',
+    }),
+    server.inject({
+      method: 'GET',
+      url: '/three',
+    }),
+  ]);
+
+  // Will cause test to time out if not fired
+  await deferred.promise;
 });


### PR DESCRIPTION
We can used request interception to ensure that each inbound request happens in it's own domain, with complete scope separation. 

This allows the use of all the standard Sentry helpers, and ensures that where or how an exception is captured it'll include all of the request context. Additionally any data added to the Sentry scope using `configureScope` or `withScope` will only be applied to the scope for the specific request.

All of this means this library now behaves the same as other Sentry libraries, but it requires the use of Domains. I haven't added the ability to op out of the use of Domains because I think doing so breaks how people expect to use Sentry.