### PR TITLE
Dependency updates and minor code changes where necessary

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+name: Builds
 
 on:
   push:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 14.x, 16.x, 18.x, 19.x, 20.x]
+        node-version: [ 14.x, 16.x, 18.x, 19.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [ 14.x, 16.x, 18.x, 19.x, 20.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # hapi-sentry
 
 [![package on npm](https://img.shields.io/npm/v/hapi-sentry.svg)](https://www.npmjs.com/package/hapi-sentry)
-[![David](https://img.shields.io/david/hydra-newmedia/hapi-sentry)](https://david-dm.org/hydra-newmedia/hapi-sentry)
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/hydra-newmedia/hapi-sentry/Node.js%20CI/master)](https://github.com/hydra-newmedia/hapi-sentry/actions/workflows/nodejs.yml)
-![node 12+ required](https://img.shields.io/badge/node-12%2B-brightgreen.svg)
+[![GitHub Workflow Status](https://github.com/hydra-newmedia/hapi-sentry/actions/workflows/nodejs.yml/badge.svg)](https://github.com/hydra-newmedia/hapi-sentry/actions/workflows/nodejs.yml)
+![node 14+ required](https://img.shields.io/badge/node-14%2B-brightgreen.svg)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/hydra-newmedia/hapi-sentry/master/LICENSE)
 
 A hapi [plugin](https://hapijs.com/api#plugins) for

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "author": "Christian Hotz <hotz@hydra-newmedia.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@hapi/hapi": "^19.0.0 || ^20.0.0"
+    "@hapi/hapi": ">=19 <22"
   },
   "dependencies": {
     "@hapi/hoek": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -43,19 +43,20 @@
     "@hapi/hapi": "^19.0.0 || ^20.0.0"
   },
   "dependencies": {
-    "@hapi/hoek": "^9.1.0",
-    "@sentry/node": "^6.2.2",
-    "joi": "^17.2.1"
+    "@hapi/hoek": "^11.0.2",
+    "@sentry/node": "^7.38.0",
+    "@sentry/types": "^7.38.0",
+    "joi": "^17.7.1"
   },
   "devDependencies": {
-    "@hapi/hapi": "^20.0.0",
-    "ava": "^3.15.0",
-    "eslint": "^7.22.0",
-    "eslint-config-airbnb-base": "^14.2.1",
-    "eslint-plugin-ava": "^12.0.0",
-    "eslint-plugin-import": "^2.22.1",
-    "husky": "^4.3.0",
-    "lint-staged": "^11.0.0",
+    "@hapi/hapi": "^21.3.0",
+    "ava": "3.15.0",
+    "eslint": "^8.34.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-plugin-ava": "^14.0.0",
+    "eslint-plugin-import": "^2.27.5",
+    "husky": "^8.0.3",
+    "lint-staged": "^13.1.2",
     "p-defer": "^3.0.0"
   }
 }

--- a/schema.js
+++ b/schema.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const { Severity } = require('@sentry/node');
 const joi = require('joi');
 
-const levels = Object.values(Severity).filter(level => typeof level === 'string')
-  || ['fatal', 'error', 'warning', 'log', 'info', 'debug', 'critical'];
+const levels = ['fatal', 'error', 'warning', 'log', 'info', 'debug'];
 
 const sentryClient = joi.object().keys({
   configureScope: joi.function().minArity(1),

--- a/test.js
+++ b/test.js
@@ -63,7 +63,9 @@ test('allows deactivating capture (opts.dsn to be false)', async t => {
   });
 
   // wait for sentry event possibly to be sent
-  await new Promise(resolve => setTimeout(resolve, 20));
+  await new Promise(resolve => {
+    setTimeout(resolve, 20);
+  });
   t.is(eventCaptured, false);
 });
 


### PR DESCRIPTION
The Sentry update eliminated the ability to get the Severity Enum cleanly, and it was already falling back on a hardcoded array, so I just struck the attempt and left the array in place.  