### PR TITLE
Draft: remove built in sentry.init functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,20 @@ request error logging to [Sentry](https://sentry.io/).
 
 Use the hapi plugin like this:
 ```JavaScript
+const hapi = require('@hapi/hapi');
+const Sentry = require('@sentry/node');
 const server = hapi.server();
+
+Sentry.init({ dsn: 'dsn-here' });
 await server.register({
   plugin: require('hapi-sentry'),
   options: {
-    client: { dsn: 'dsn-here' },
+    client: Sentry,
   },
 });
 ```
 
 This setup will:
-* Initialize Sentry regularly, which should capture all global errors and unhandled promise rejects
 * Capture all unhandled exceptions thrown or returned in routes
 * Use request data and `request.auth.credentials` to enhance errors from routes
 
@@ -39,18 +42,7 @@ The plugin options, you can pass in while registering are the following:
 | `scope.tags.name`         | string        | The name of a tag                                                                                                            |
 | `scope.tags.value`        | any           | The value of a tag                                                                                                           |
 | `scope.extra`             | object        | An object of arbitrary format to be sent as extra data on every event                                                        |
-| `client`                  | object        | **required** A [@sentry/node](https://www.npmjs.com/package/@sentry/node) instance which was already initialized (using `Sentry.init`) OR an options object to be passed to an internally initialized [@sentry/node](https://www.npmjs.com/package/@sentry/node) (`client.dsn` is only required in the latter case) |
-| `client.dsn`              | string/false  | **required** The Dsn used to connect to Sentry and identify the project. If false, the SDK will not send any data to Sentry. |
-| `client.debug`            | boolean       | Turn debug mode on/off                                                                                                       |
-| `client.release`          | string        | Tag events with the version/release identifier of your application                                                           |
-| `client.environment`      | string        | The current environment of your application (e.g. `'production'`)                                                            |
-| `client.sampleRate`       | number        | A global sample rate to apply to all events (0 - 1)                                                                          |
-| `client.maxBreadcrumbs`   | number        | The maximum number of breadcrumbs sent with events. Default: `100`                                                           |
-| `client.attachStacktrace` | any           | Attaches stacktraces to pure capture message / log integrations                                                              |
-| `client.sendDefaultPii`   | boolean       | If this flag is enabled, certain personally identifiable information is added by active integrations                         |
-| `client.serverName`       | string        | Overwrite the server name (device name)                                                                                      |
-| `client.beforeSend`       | func          | A callback invoked during event submission, allowing to optionally modify the event before it is sent to Sentry              |
-| `client.beforeBreadcrumb` | func          | A callback invoked when adding a breadcrumb, allowing to optionally modify it before adding it to future events.             |
+| `client`                  | object        | **required** A [@sentry/node](https://www.npmjs.com/package/@sentry/node) instance which was already initialized (using `Sentry.init`) |
 | `trackUser`               | boolean       | Whether or not to track the user via the per-request scope. Default: `true`                                                  |
 | `catchLogErrors`          | boolean/array | Handles [capturing server.log and request.log events](#capturing-serverlog-and-requestlog-events). Default: `false`          |
 | `useDomainPerRequest`     | boolean       | Whether or not to use [Domains](https://nodejs.org/docs/latest-v12.x/api/domain.html) for seperating request processing. Only activate this feature, if you really need to seperate breadcrumbs, etc. of requests. It utilizes a deprecated Node.js feature which reduces [performance](https://github.com/hydra-newmedia/hapi-sentry/pull/21#issuecomment-574602486). Default: `false` |
@@ -58,23 +50,7 @@ The plugin options, you can pass in while registering are the following:
 The `baseUri` option is used internally to get a correct URL in sentry issues.
 The `scope` option is used to set up a global
 [`Scope`](http://getsentry.github.io/sentry-javascript/classes/hub.scope.html)
-for all events and the
-[`client`](http://getsentry.github.io/sentry-javascript/interfaces/node.nodeoptions.html) option
-is used as a Sentry instance or to initialize an internally used Sentry instance.
-
-The internally used client (initialized in either way) is accessible through
-`server.plugins['hapi-sentry'].client`.
-
-## Using your own Sentry instance
-
-You can pass a `Sentry` instance to  the `client` option if you already initialized your own like this:
-
-```js
-const server = hapi.server();
-const Sentry = require('sentry');
-Sentry.init({ dsn: 'dsn-here' });
-await server.register({ plugin: require('hapi-sentry'), options: { client: Sentry } });
-```
+for all events.
 
 ## Scope
 

--- a/index.js
+++ b/index.js
@@ -10,14 +10,7 @@ const schema = require('./schema');
 exports.register = (server, options) => {
   const opts = joi.attempt(options, schema, 'Invalid hapi-sentry options:');
 
-  let Sentry = opts.client;
-  // initialize own sentry client if none passed as option
-  if (opts.client.dsn !== undefined) {
-    // eslint-disable-next-line global-require
-    Sentry = require('@sentry/node');
-    Sentry.init(opts.client);
-  }
-
+  const Sentry = opts.client;
   // initialize global scope if set via plugin options
   if (opts.scope) {
     Sentry.configureScope(scope => {

--- a/package.json
+++ b/package.json
@@ -35,12 +35,11 @@
   "author": "Christian Hotz <hotz@hydra-newmedia.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@hapi/hapi": ">=19 <22"
+    "@hapi/hapi": ">=19 <22",
+    "@sentry/node": "^7.49.0"
   },
   "dependencies": {
     "@hapi/hoek": "^11.0.2",
-    "@sentry/node": "^7.38.0",
-    "@sentry/types": "^7.38.0",
     "joi": "^17.7.1"
   },
   "devDependencies": {

--- a/schema.js
+++ b/schema.js
@@ -14,10 +14,6 @@ const sentryClient = joi.object().keys({
   captureException: joi.function().minArity(1).required(),
 }).unknown();
 
-const sentryOptions = joi.object().keys({
-  dsn: joi.string().uri().allow(false).required(),
-}).unknown();
-
 module.exports = joi.object().keys({
   baseUri: joi.string().uri(),
   trackUser: joi.boolean().default(true),
@@ -29,7 +25,7 @@ module.exports = joi.object().keys({
     level: joi.string().valid(...levels),
     extra: joi.object(),
   }),
-  client: joi.alternatives().try(sentryOptions, sentryClient).required(),
+  client: sentryClient,
   catchLogErrors: joi.alternatives().try(
     joi.boolean(),
     joi.array().items(joi.string()),


### PR DESCRIPTION
The user now always needs to init Sentry and pass it to the plugin. This improves compatibility in certain cases. Eg. when mixing @sentry/node with other sentry packages like @sentry/remix.